### PR TITLE
doc: JSON with JSON Schema in list of validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository is attempt to converge across wider range of standards/tools.
   - [bids-validator:1878 "Provide means (result records schema) for external validators (e.g. NWB)"](https://github.com/bids-standard/bids-validator/issues/1878)
 - HDF5
 - HED
-- JSON
+- [JSON Schema](https://json-schema.org/)
 - NGFF/OME-Zarr
 - NWB
   - nwb-inspector 


### PR DESCRIPTION
JSON doesn't provide validation of any data instances but JSON Schema does. I think JSON Schema is what was originally intended. 

Additionally, is the listing of `YAML` needed since it seems that `YAML` is really `JSON Schema` specified in YAML format?